### PR TITLE
Add :varied type

### DIFF
--- a/lib/config_volumizer.rb
+++ b/lib/config_volumizer.rb
@@ -29,7 +29,7 @@ module ConfigVolumizer
     # @return [Object]
     def fetch(source, mapping_key, mapping_info, default=nil, &block)
       value = Parser.parse(source, mapping_key => mapping_info)
-      value.fetch(mapping_key, *[default].compact, &block)
+      value.fetch(mapping_key.to_s, *[default].compact, &block)
     end
 
     # Generates a flattened config out of a data hash

--- a/lib/config_volumizer/generator.rb
+++ b/lib/config_volumizer/generator.rb
@@ -41,7 +41,9 @@ module ConfigVolumizer
           value.each_with_index do |item, index|
             result[index] = process_mapping_item(item)
           end
-          result.uniq
+          result.uniq!
+          result = [:varied] if result.length > 1
+          result
         when Hash
           result = {}
           value.each do |key, item|

--- a/lib/config_volumizer/parser.rb
+++ b/lib/config_volumizer/parser.rb
@@ -53,6 +53,14 @@ module ConfigVolumizer
           new_name = name.gsub(/^#{mapping_key}_/, '')
           result[mapping_key] ||= {}
           result[mapping_key][new_name] = format_value(value)
+        when :varied
+          new_name = name.gsub(/^#{mapping_key}_/, '')
+          if new_name == "" || name == mapping_key
+            result[mapping_key] = format_value(value)
+          else
+            result[mapping_key] ||= {}
+            result[mapping_key][new_name] = format_value(value)
+            end
         else
           raise ArgumentError, "don't know how to deal with #{mapping_info.inspect}"
         end
@@ -77,6 +85,13 @@ module ConfigVolumizer
             result[mapping_key] += format_array_value(value)
           when :hash, Hash
             handle_array_hash_item(inner_mapping_info, mapping_key, name, result, value)
+          when :varied
+            new_name = name.gsub(/^#{mapping_key}_(\d+)(?:_)?/, '')
+            if new_name == ""
+              result[mapping_key] += format_array_value(value) # value mode
+            else
+              handle_array_hash_item(inner_mapping_info, mapping_key, name, result, value) # hash mode
+            end
           else
             raise "don't know how to handle: #{inner_mapping_info.inspect}"
           end

--- a/lib/config_volumizer/parser.rb
+++ b/lib/config_volumizer/parser.rb
@@ -68,9 +68,11 @@ module ConfigVolumizer
       end
 
       def handle_hash_item(mapping_info, mapping_key, name, result, value)
+        mapping_key = mapping_key.to_s if mapping_key.kind_of?(Symbol)
         result[mapping_key] ||= {}
         new_name = name.gsub(/^#{mapping_key}_/, '')
         mapping_info.each do |inner_mapping_key, inner_mapping_info|
+          inner_mapping_key = inner_mapping_key.to_s if inner_mapping_key.kind_of?(Symbol)
           if matches_name(inner_mapping_key, new_name)
             handle_item(result[mapping_key], new_name, value, inner_mapping_key, inner_mapping_info)
           end

--- a/lib/config_volumizer/parser.rb
+++ b/lib/config_volumizer/parser.rb
@@ -18,7 +18,8 @@ module ConfigVolumizer
       def parse(source, mapping)
         result = {}
         mapping.each do |mapping_key, mapping_info|
-          source.each do |key, value|
+          source.keys.sort.each do |key|
+            value = source[key]
             if matches_name(mapping_key, key)
               handle_item(result, key, value, mapping_key, mapping_info)
             end

--- a/spec/config_volumizer_spec.rb
+++ b/spec/config_volumizer_spec.rb
@@ -324,6 +324,88 @@ describe ConfigVolumizer do
       end
     end
 
+    describe "varied values at root" do
+      let(:mapping) do
+        {
+          "ex" => :varied
+        }
+      end
+
+      context "value mode" do
+        let(:input) do
+          {
+            'ex' => "1a",
+          }
+        end
+
+        let(:expected_result) do
+          {
+            'ex' => "1a"
+          }
+        end
+
+        example do
+          expect(result).to eq(expected_result)
+        end
+      end
+
+      context "hash mode" do
+        let(:input) do
+          {
+            'ex_one' => "1a",
+            'ex_two' => "1b",
+          }
+        end
+
+        let(:expected_result) do
+          {
+            'ex' => {
+              "one" => "1a",
+              "two" => "1b",
+            }
+          }
+        end
+
+        example do
+          expect(result).to eq(expected_result)
+        end
+      end
+    end
+
+    describe "array with varied values" do
+      let(:mapping) do
+        {
+          "ex" => [
+            :varied
+          ]
+        }
+      end
+      let(:input) do
+        {
+          'ex_0' => "1a",
+          'ex_1' => "2a",
+          'ex_2_one' => "3a",
+          'ex_2_two' => "3b",
+        }
+      end
+      let(:expected_result) do
+        {
+          'ex' => [
+            '1a',
+            '2a',
+            {
+              'one' => '3a',
+              'two' => '3b',
+            }
+          ]
+        }
+      end
+
+      example do
+        expect(result).to eq(expected_result)
+      end
+    end
+
   end
 
   describe "fetch" do

--- a/spec/config_volumizer_spec.rb
+++ b/spec/config_volumizer_spec.rb
@@ -18,21 +18,21 @@ describe ConfigVolumizer do
       let(:mapping) {
         {
           "ex1" => {
-            "bar" => :value,
+            "bar"  => :value,
             "bar2" => :value,
           }
         }
       }
       let(:input) do
         {
-          "ex1_bar" => "1a",
+          "ex1_bar"  => "1a",
           "ex1_bar2" => "2a",
         }
       end
       let(:expected_result) do
         {
           'ex1' => {
-            'bar' => '1a',
+            'bar'  => '1a',
             'bar2' => '2a',
           },
         }
@@ -48,7 +48,7 @@ describe ConfigVolumizer do
         {
           "ex3" => {
             "one" => {
-              "two" => :value,
+              "two"   => :value,
               "three" => :value,
             },
             "two" => {
@@ -59,7 +59,7 @@ describe ConfigVolumizer do
       end
       let(:input) do
         {
-          "ex3_one_two" => "1a",
+          "ex3_one_two"   => "1a",
           "ex3_one_three" => "2a",
           "ex3_two_three" => "3a",
         }
@@ -68,7 +68,7 @@ describe ConfigVolumizer do
         {
           'ex3' => {
             'one' => {
-              'two' => '1a',
+              'two'   => '1a',
               'three' => '2a',
             },
             'two' => {
@@ -237,16 +237,16 @@ describe ConfigVolumizer do
         end
         let(:input) do
           {
-            'ex_one' => "1a",
-            'ex_two' => "2a",
+            'ex_one'   => "1a",
+            'ex_two'   => "2a",
             'ex_three' => "3a",
           }
         end
         let(:expected_result) do
           {
             'ex' => {
-              "one" => "1a",
-              "two" => "2a",
+              "one"   => "1a",
+              "two"   => "2a",
               "three" => "3a",
             }
           }
@@ -267,8 +267,8 @@ describe ConfigVolumizer do
         end
         let(:input) do
           {
-            'ex_ex2_one' => "1a",
-            'ex_ex2_two' => "2a",
+            'ex_ex2_one'   => "1a",
+            'ex_ex2_two'   => "2a",
             'ex_ex2_three' => "3a",
           }
         end
@@ -276,8 +276,8 @@ describe ConfigVolumizer do
           {
             'ex' => {
               'ex2' => {
-                "one" => "1a",
-                "two" => "2a",
+                "one"   => "1a",
+                "two"   => "2a",
                 "three" => "3a",
               }
             }
@@ -297,18 +297,18 @@ describe ConfigVolumizer do
         end
         let(:input) do
           {
-            'ex_0_one' => "1a",
-            'ex_0_two' => "2a",
+            'ex_0_one'   => "1a",
+            'ex_0_two'   => "2a",
             'ex_0_three' => "3a",
-            'ex_1_two' => "4a",
+            'ex_1_two'   => "4a",
           }
         end
         let(:expected_result) do
           {
             'ex' => [
               {
-                "one" => "1a",
-                "two" => "2a",
+                "one"   => "1a",
+                "two"   => "2a",
                 "three" => "3a",
               },
               {
@@ -379,20 +379,20 @@ describe ConfigVolumizer do
             foo1: :value,
             bar1: [:varied],
             foo2: :value,
-            bar2: [{x: :value}],
+            bar2: [{ x: :value }],
           }
         }
       end
       let(:input) do
         {
-          'ex_foo1' => "0a",
-          'ex_bar1_0' => "1a",
-          'ex_bar1_1' => "2a",
+          'ex_foo1'       => "0a",
+          'ex_bar1_0'     => "1a",
+          'ex_bar1_1'     => "2a",
           'ex_bar1_2_one' => "3a",
           'ex_bar1_2_two' => "3b",
-          'ex_foo2' => "4a",
-          'ex_bar2_0_x' => "5a",
-          'ex_bar2_1_x' => "5b",
+          'ex_foo2'       => "4a",
+          'ex_bar2_0_x'   => "5a",
+          'ex_bar2_1_x'   => "5b",
         }
       end
       let(:expected_result) do
@@ -409,8 +409,8 @@ describe ConfigVolumizer do
             ],
             'foo2' => '4a',
             'bar2' => [
-              {'x' => '5a'},
-              {'x' => '5b'},
+              { 'x' => '5a' },
+              { 'x' => '5b' },
             ],
           }
         }
@@ -430,16 +430,16 @@ describe ConfigVolumizer do
     context "basic example" do
       let(:env) do
         {
-          "some_gem_settings_one" => "hello",
-          "some_gem_settings_two" => "world",
+          "some_gem_settings_one"   => "hello",
+          "some_gem_settings_two"   => "world",
           "some_gem_settings_three" => "yay",
         }
       end
       let(:mapping) { :hash }
       let(:expected) do
         {
-          "one" => "hello",
-          "two" => "world",
+          "one"   => "hello",
+          "two"   => "world",
           "three" => "yay",
         }
       end
@@ -450,9 +450,9 @@ describe ConfigVolumizer do
     context "complex example" do
       let(:env) do
         {
-          "some_gem_settings_key1_one" => "hello1",
-          "some_gem_settings_key1_two" => "hello2",
-          "some_gem_settings_key2" => "hello,world",
+          "some_gem_settings_key1_one"       => "hello1",
+          "some_gem_settings_key1_two"       => "hello2",
+          "some_gem_settings_key2"           => "hello,world",
           "some_gem_settings_key3_0_foo_one" => "1",
           "some_gem_settings_key3_0_foo_two" => "2",
           "some_gem_settings_key3_1_foo_one" => "3",
@@ -489,8 +489,8 @@ describe ConfigVolumizer do
       let(:key_name) { "not_found" }
       let(:env) do
         {
-          "some_gem_settings_one" => "hello",
-          "some_gem_settings_two" => "world",
+          "some_gem_settings_one"   => "hello",
+          "some_gem_settings_two"   => "world",
           "some_gem_settings_three" => "yay",
         }
       end
@@ -521,4 +521,37 @@ describe ConfigVolumizer do
     end
   end
 
+  context "edge cases" do
+    let(:env) do
+      {
+        "app_cache_store_2_namespace"       => "some",
+        "app_cache_store_1"                 => "some.server.net",
+        "app_cache_store_0"                 => "dalli_store",
+        "app_cache_store_2_expires_in"      => "86400",
+        "app_cache_store_2_value_max_bytes" => "2097152"
+      }
+    end
+
+    let(:mapping) do
+      [:varied]
+    end
+
+    let(:result) { ConfigVolumizer.fetch(env, 'app_cache_store', mapping) }
+
+    let(:expected) do
+      [
+        "dalli_store",
+        "some.server.net",
+        {
+          "namespace"       => "some",
+          "expires_in"      => 86400,
+          "value_max_bytes" => 2097152
+        }
+      ]
+    end
+
+    example do
+      expect(result).to eq(expected)
+    end
+  end
 end

--- a/spec/config_volumizer_spec.rb
+++ b/spec/config_volumizer_spec.rb
@@ -375,29 +375,44 @@ describe ConfigVolumizer do
     describe "array with varied values" do
       let(:mapping) do
         {
-          "ex" => [
-            :varied
-          ]
+          "ex" => {
+            foo1: :value,
+            bar1: [:varied],
+            foo2: :value,
+            bar2: [{x: :value}],
+          }
         }
       end
       let(:input) do
         {
-          'ex_0' => "1a",
-          'ex_1' => "2a",
-          'ex_2_one' => "3a",
-          'ex_2_two' => "3b",
+          'ex_foo1' => "0a",
+          'ex_bar1_0' => "1a",
+          'ex_bar1_1' => "2a",
+          'ex_bar1_2_one' => "3a",
+          'ex_bar1_2_two' => "3b",
+          'ex_foo2' => "4a",
+          'ex_bar2_0_x' => "5a",
+          'ex_bar2_1_x' => "5b",
         }
       end
       let(:expected_result) do
         {
-          'ex' => [
-            '1a',
-            '2a',
-            {
-              'one' => '3a',
-              'two' => '3b',
-            }
-          ]
+          'ex' => {
+            'foo1' => '0a',
+            'bar1' => [
+              '1a',
+              '2a',
+              {
+                'one' => '3a',
+                'two' => '3b',
+              }
+            ],
+            'foo2' => '4a',
+            'bar2' => [
+              {'x' => '5a'},
+              {'x' => '5b'},
+            ],
+          }
         }
       end
 

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -10,21 +10,34 @@ describe ConfigVolumizer do
           "six" => [
             "seven",
             "eight",
-          ]
-        }
+          ],
+        },
+        "nine" => [
+          "one",
+          "two",
+          {
+            "one" => 1,
+            "two" => 2,
+          }
+        ],
       }
       expected_env_data = {
         "one" => "two",
         "three_four" => "five",
         "three_six_0" => "seven",
         "three_six_1" => "eight",
+        "nine_0" => "one",
+        "nine_1" => "two",
+        "nine_2_one" => 1,
+        "nine_2_two" => 2,
       }
       expected_mapping_data = {
         "one" => :value,
         "three" => {
           "four" => :value,
           "six" => [:value]
-        }
+        },
+        "nine" => [:varied],
       }
       result = described_class.generate(data)
       expect(result.env_hash).to eq(expected_env_data)


### PR DESCRIPTION
This adds a new type `:varied` which creates a bit more flexibility on how data is retrieved.

Had an issue with a particular config format where there was an array that had some `:value` elements and some `:hash` elements.

eg:

```
["one", "two", {three: "four"}]
```

can now be represented properly.